### PR TITLE
Test : Customer, OfficeOwner 회원가입 기능 테스트 코드 작성 및 버그수정

### DIFF
--- a/src/main/java/com/dokkebi/officefinder/controller/auth/dto/Auth.java
+++ b/src/main/java/com/dokkebi/officefinder/controller/auth/dto/Auth.java
@@ -2,8 +2,10 @@ package com.dokkebi.officefinder.controller.auth.dto;
 
 import com.dokkebi.officefinder.entity.Customer;
 import com.dokkebi.officefinder.entity.OfficeOwner;
+import java.util.Set;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +18,7 @@ public class Auth {
    */
   @Getter
   @NoArgsConstructor
+  @AllArgsConstructor
   public static class SignUpCustomer {
     @NotBlank
     private String name;
@@ -30,6 +33,8 @@ public class Auth {
           .name(name)
           .password(password)
           .email(email)
+          .point(0)
+          .roles(Set.of("ROLE_CUSTOMER"))
           .build();
     }
 
@@ -57,6 +62,7 @@ public class Auth {
    */
   @Getter
   @NoArgsConstructor
+  @AllArgsConstructor
   public static class SignUpOfficeOwner {
     @NotBlank
     private String name;
@@ -74,6 +80,8 @@ public class Auth {
           .password(password)
           .email(email)
           .businessNumber(businessNumber)
+          .point(0)
+          .roles(Set.of("ROLE_OFFICE_OWNER"))
           .build();
     }
 

--- a/src/main/java/com/dokkebi/officefinder/entity/Customer.java
+++ b/src/main/java/com/dokkebi/officefinder/entity/Customer.java
@@ -48,15 +48,6 @@ public class Customer extends BaseEntity {
     this.roles = roles;
   }
 
-  @Builder
-  private Customer(String name, String email, String password) {
-    this.name = name;
-    this.email = email;
-    this.password = password;
-    this.point = 0;
-    this.roles = Set.of("ROLE_CUSTOMER");
-  }
-
   /*
     회원 비밀번호 변경 메서드
      */

--- a/src/main/java/com/dokkebi/officefinder/entity/OfficeOwner.java
+++ b/src/main/java/com/dokkebi/officefinder/entity/OfficeOwner.java
@@ -55,16 +55,6 @@ public class OfficeOwner extends BaseEntity {
     this.roles = roles;
   }
 
-  @Builder
-  private OfficeOwner(String name, String email, String password, String businessNumber) {
-    this.name = name;
-    this.email = email;
-    this.password = password;
-    this.businessNumber = businessNumber;
-    this.point = 0;
-    this.roles = Set.of("ROLE_OFFICE_OWNER");
-  }
-
   public void changePassword(String newPassword) {
     this.password = newPassword;
   }

--- a/src/test/java/com/dokkebi/officefinder/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/dokkebi/officefinder/service/auth/AuthServiceTest.java
@@ -1,0 +1,144 @@
+package com.dokkebi.officefinder.service.auth;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+
+import com.dokkebi.officefinder.controller.auth.dto.Auth;
+import com.dokkebi.officefinder.entity.Customer;
+import com.dokkebi.officefinder.entity.OfficeOwner;
+import com.dokkebi.officefinder.exception.CustomErrorCode;
+import com.dokkebi.officefinder.exception.CustomException;
+import com.dokkebi.officefinder.repository.CustomerRepository;
+import com.dokkebi.officefinder.repository.OfficeOwnerRepository;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock
+  private CustomerRepository customerRepository;
+  @Mock
+  private OfficeOwnerRepository officeOwnerRepository;
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @InjectMocks
+  private AuthService authService;
+
+  @Test
+  @DisplayName("Customer 회원가입 성공")
+  void registerCustomer_Success() {
+    // given
+    Auth.SignUpCustomer customer = new Auth.SignUpCustomer("honghong","bippr@gmail.com","password");
+
+    given(customerRepository.existsByEmail(anyString()))
+        .willReturn(false);
+
+    given(passwordEncoder.encode(anyString())).willReturn("encodedPassword");
+
+    given(customerRepository.save(any(Customer.class)))
+        .willReturn(Customer.builder()
+            .name("hong")
+            .email("bippr@gmail.com")
+            .password("encodedPassword")
+            .point(0)
+            .roles(Set.of("ROLE_CUSTOMER"))
+            .build());
+
+    ArgumentCaptor<Customer> captor = ArgumentCaptor.forClass(Customer.class);
+
+
+    // when
+    Auth.SignUpResponseCustomer response = authService.register(customer);
+
+    // then
+    Mockito.verify(customerRepository, times(1)).save(captor.capture());
+    assertEquals("hong", response.getName());
+    assertEquals("honghong",captor.getValue().getName());
+    assertEquals("bippr@gmail.com",captor.getValue().getEmail());
+    assertEquals("encodedPassword", captor.getValue().getPassword());
+  }
+
+  @Test
+  @DisplayName("Customer 회원가입 실패 - 이미 등록된 이메일")
+  void registerCustomer_Fail(){
+    //given
+    Auth.SignUpCustomer customer = new Auth.SignUpCustomer("hong","bippr@gmail.com","password");
+
+    given(customerRepository.existsByEmail(anyString()))
+        .willReturn(true);
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> authService.register(customer));
+
+    //then
+    assertEquals(CustomErrorCode.EMAIL_ALREADY_REGISTERED, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("OfficeOwner 회원가입 성공")
+  void registerOfficeOwner_Success() {
+    // given
+    Auth.SignUpOfficeOwner officeOwner = new Auth.SignUpOfficeOwner("hongOwner","bippr@gmail.com","12345","password");
+
+    given(officeOwnerRepository.existsByEmail(anyString()))
+        .willReturn(false);
+
+    given(passwordEncoder.encode(anyString())).willReturn("encodedPassword");
+
+    given(officeOwnerRepository.save(any(OfficeOwner.class)))
+        .willReturn(OfficeOwner.builder()
+            .name("hong")
+            .email("bippr@gmail.com")
+            .password("encodedPassword")
+            .businessNumber("12345")
+            .point(0)
+            .roles(Set.of("ROLE_OFFICE_OWNER"))
+            .build());
+
+    ArgumentCaptor<OfficeOwner> captor = ArgumentCaptor.forClass(OfficeOwner.class);
+
+    // when
+    Auth.SignUpResponseOfficeOwner response = authService.register(officeOwner);
+
+    // then
+    Mockito.verify(officeOwnerRepository, times(1)).save(captor.capture());
+    assertEquals("hong", response.getName());
+    assertEquals("hongOwner",captor.getValue().getName());
+    assertEquals("bippr@gmail.com",captor.getValue().getEmail());
+    assertEquals("12345",captor.getValue().getBusinessNumber());
+    assertEquals("encodedPassword", captor.getValue().getPassword());
+  }
+
+  @Test
+  @DisplayName("OfficeOwner 회원가입 실패 - 이미 등록된 이메일")
+  void registerOfficeOwner_Fail(){
+    //given
+    Auth.SignUpOfficeOwner officeOwner = new Auth.SignUpOfficeOwner("hong","bippr@gmail.com", "12345","password");
+
+    given(officeOwnerRepository.existsByEmail(anyString()))
+        .willReturn(true);
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> authService.register(officeOwner));
+
+    //then
+    assertEquals(CustomErrorCode.EMAIL_ALREADY_REGISTERED, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
- Fix : 이전에 Customer, OfficeOwner 엔티티에 @Builder 생성자를 하나 더 추가하고 생성자 안에서 디폴트값을 설정했었는데, 디폴트값이 제대로 반영이 안되는 버그를 발견함. @Builder가 붙는 생성자를 여러개 만들면 생성자가 제대로 작동이 안되는듯함. 추가한 생성자를 삭제하고 Service layer에서 디폴트값을 지정해서 회원정보를 저장해줌