### PR TITLE
Feat : Jwt 인증 기능 구현

### DIFF
--- a/src/main/java/com/dokkebi/officefinder/controller/auth/TestController.java
+++ b/src/main/java/com/dokkebi/officefinder/controller/auth/TestController.java
@@ -1,0 +1,32 @@
+package com.dokkebi.officefinder.controller.auth;
+
+import com.dokkebi.officefinder.security.TokenProvider;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TestController {
+
+  private final TokenProvider tokenProvider;
+
+  @PreAuthorize(("hasRole('OFFICE_OWNER')"))
+//  @PreAuthorize("hasRole('CUSTOMER')")
+  @GetMapping("/test")
+  public String test(HttpServletRequest request, @RequestHeader("Authorization") String jwtHeader) {
+    // 유저 email 추출
+    String email = request.getUserPrincipal().getName();
+    System.out.println(email);
+    // 유저 id 추출
+    Long id = tokenProvider.getUserIdFromHeader(jwtHeader);
+    System.out.println(id);
+    return "success";
+  }
+}

--- a/src/main/java/com/dokkebi/officefinder/entity/Customer.java
+++ b/src/main/java/com/dokkebi/officefinder/entity/Customer.java
@@ -1,7 +1,9 @@
 package com.dokkebi.officefinder.entity;
 
 import com.dokkebi.officefinder.utils.Converter;
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -12,11 +14,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Customer extends BaseEntity {
+public class Customer extends BaseEntity implements UserDetails {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -71,5 +76,37 @@ public class Customer extends BaseEntity {
       throw new IllegalArgumentException("포인트가 부족합니다. 충전해 주세요");
     }
     this.point -= requiredPoint;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return roles.stream()
+        .map(SimpleGrantedAuthority::new)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public String getUsername() {
+    return this.email;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return false;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
   }
 }

--- a/src/main/java/com/dokkebi/officefinder/entity/OfficeOwner.java
+++ b/src/main/java/com/dokkebi/officefinder/entity/OfficeOwner.java
@@ -1,7 +1,9 @@
 package com.dokkebi.officefinder.entity;
 
 import com.dokkebi.officefinder.utils.Converter;
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -14,12 +16,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-public class OfficeOwner extends BaseEntity {
+public class OfficeOwner extends BaseEntity implements UserDetails {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -63,4 +68,38 @@ public class OfficeOwner extends BaseEntity {
   public void addPoint(int additionalPoint) {
     this.point += additionalPoint;
   }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return roles.stream()
+        .map(SimpleGrantedAuthority::new)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public String getUsername() {
+    return this.email;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return false;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+
+
 }

--- a/src/main/java/com/dokkebi/officefinder/exception/CustomErrorCode.java
+++ b/src/main/java/com/dokkebi/officefinder/exception/CustomErrorCode.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 public enum CustomErrorCode {
 
   EMAIL_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "가입되어 있지 않은 이메일입니다."),
+  USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "유저를 찾을 수 없습니다."),
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "요청 접근 권한이 없습니다."),
   EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 등록된 이메일입니다."),
   PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "입력하신 비밀번호가 올바르지 않습니다.");

--- a/src/main/java/com/dokkebi/officefinder/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dokkebi/officefinder/security/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.dokkebi.officefinder.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter { //OncePerRequestFilter는 요청이 올때마다 이 필터가 실행됨.
+  @Value("${spring.jwt.token-header}")
+  private String TOKEN_HEADER;
+
+  private final TokenProvider tokenProvider;
+
+  /*
+      요청이 올때마다 실행되는 Filter, 토큰을 검증하고, 검증된 유저를 등록하는 과정
+   */
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    String token = resolveTokenFromRequest(request); // 요청 헤더에서 jwt 토큰 가져오기
+
+    if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) { //토큰이 시간만료되었는지 체크
+      Authentication auth = tokenProvider.getAuthentication(token); // 사용자와 사용자권한정보가 포함된 인증토큰 리턴
+      SecurityContextHolder.getContext().setAuthentication(auth);
+
+      log.info(String.format("[%s_%s] -> %s",tokenProvider.getUserType(token), tokenProvider.getUserId(token), request.getRequestURI()));
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  /*
+      헤더에서 jwt토큰을 추출하는 메서드
+   */
+  private String resolveTokenFromRequest(HttpServletRequest request) {
+    return tokenProvider.resolveTokenFromHeader(request.getHeader(TOKEN_HEADER));
+  }
+}
+

--- a/src/main/java/com/dokkebi/officefinder/security/SecurityConfig.java
+++ b/src/main/java/com/dokkebi/officefinder/security/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.dokkebi.officefinder.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@Slf4j
+@Configuration
+@EnableWebSecurity(debug = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  /*
+      client에서 요청을 날리면 Spring Security의 여러 filterChain 들을 거치게 됨.
+      그 체인들에 대한 설정을 하는 Bean 임.
+      disable()로 특정 필터를 거치지않게 할 수 있음.
+   */
+  private final JwtAuthenticationFilter authenticationFilter;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http    .httpBasic().disable()
+        .csrf().disable()
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        .and()
+        .authorizeHttpRequests((authz) -> authz
+            .antMatchers("/**/signup", "/**/login").permitAll()
+            .anyRequest().authenticated()
+        )
+        .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
+
+//  @Bean
+//  public WebSecurityCustomizer webSecurityCustomizer() {
+//    return (web) -> web.ignoring()
+//        //.antMatchers("/ignore1", "/ignore2")
+//        .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+//  }
+
+}

--- a/src/main/java/com/dokkebi/officefinder/security/TokenProvider.java
+++ b/src/main/java/com/dokkebi/officefinder/security/TokenProvider.java
@@ -1,11 +1,17 @@
 package com.dokkebi.officefinder.security;
 
+import com.dokkebi.officefinder.service.auth.UserDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import io.jsonwebtoken.*;
 
 import java.util.Date;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
@@ -13,8 +19,13 @@ public class TokenProvider {
 
   private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 24 hour
 
+  private final UserDetailService userDetailService;
+
   @Value("${spring.jwt.secret}")
   private String secretKey;
+
+  @Value("${spring.jwt.token-prefix}")
+  private String tokenPrefix;
 
   public String generateToken(Long id, String username, String userType) {
     Claims claims = Jwts.claims().setSubject(userType);
@@ -30,5 +41,46 @@ public class TokenProvider {
         .setExpiration(expiredDate)
         .signWith(SignatureAlgorithm.HS512, secretKey)
         .compact();
+  }
+
+  public Authentication getAuthentication(String token) {
+    UserDetails userDetails = userDetailService.loadUserById(this.getUserType(token),this.getUserId(token));
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  public String getUserType(String token) {
+    return parseClaims(token).getSubject();
+  }
+
+  public Long getUserId(String token) {
+    return parseClaims(token).get("id", Long.class);
+  }
+
+  public Long getUserIdFromHeader(String header) {
+    return this.getUserId(this.resolveTokenFromHeader(header));
+  }
+
+  public boolean validateToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      return false; //빈문자열인지 체크
+    }
+
+    Claims claims = parseClaims(token);
+    return !claims.getExpiration().before(new Date()); // 만기가 지난 토큰인지 체크
+  }
+
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    }
+  }
+
+  public String resolveTokenFromHeader(String header) {
+    if (!ObjectUtils.isEmpty(header) && header.startsWith(tokenPrefix)) {
+      return header.substring(tokenPrefix.length());
+    }
+    return null;
   }
 }

--- a/src/main/java/com/dokkebi/officefinder/service/auth/AuthService.java
+++ b/src/main/java/com/dokkebi/officefinder/service/auth/AuthService.java
@@ -23,85 +23,87 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AuthService {
 
-    private final CustomerRepository customerRepository;
-    private final OfficeOwnerRepository officeOwnerRepository;
-    private final TokenProvider tokenProvider;
-    private final PasswordEncoder passwordEncoder;
+  private final CustomerRepository customerRepository;
+  private final OfficeOwnerRepository officeOwnerRepository;
+  private final TokenProvider tokenProvider;
+  private final PasswordEncoder passwordEncoder;
 
-    /*
-        회원 등록
-        - register 메소드 오버로딩
-        1. client가 요청보낸 회원가입 정보를 가져와서 이미 가입된 email인지 확인
-        2. 이미 등록된 email이면 예외발생
-        3. 중복이 없으면 비밀번호는 암호화 처리 후 setPassword
-        4. SignUpDto 객체를 Entity객체로 변환 후 DB에 저장(회원가입 완료)
-        5. SignUpResponse Dto를 controller에 리턴
-     */
-    @Transactional
-    public Auth.SignUpResponseCustomer register(Auth.SignUpCustomer signupRequest) {
-        if (customerRepository.existsByEmail(signupRequest.getEmail())) {
-            throw new CustomException(CustomErrorCode.EMAIL_ALREADY_REGISTERED);
-        }
-
-        signupRequest.encodePassword(passwordEncoder);
-        Customer customer = customerRepository.save(signupRequest.toEntity());
-        return Auth.SignUpResponseCustomer.builder().customer(customer).build();
+  /*
+      회원 등록
+      - register 메소드 오버로딩
+      1. client가 요청보낸 회원가입 정보를 가져와서 이미 가입된 email인지 확인
+      2. 이미 등록된 email이면 예외발생
+      3. 중복이 없으면 비밀번호는 암호화 처리 후 setPassword
+      4. SignUpDto 객체를 Entity객체로 변환 후 DB에 저장(회원가입 완료)
+      5. SignUpResponse Dto를 controller에 리턴
+   */
+  @Transactional
+  public Auth.SignUpResponseCustomer register(Auth.SignUpCustomer signupRequest) {
+    if (customerRepository.existsByEmail(signupRequest.getEmail())) {
+      throw new CustomException(CustomErrorCode.EMAIL_ALREADY_REGISTERED);
     }
 
+    signupRequest.encodePassword(passwordEncoder);
+    Customer customer = customerRepository.save(signupRequest.toEntity());
+    return Auth.SignUpResponseCustomer.builder().customer(customer).build();
+  }
 
-    @Transactional
-    public Auth.SignUpResponseOfficeOwner register(Auth.SignUpOfficeOwner signupRequest) {
-        if (officeOwnerRepository.existsByEmail(signupRequest.getEmail())) {
-            throw new CustomException(CustomErrorCode.EMAIL_ALREADY_REGISTERED);
-        }
 
-        signupRequest.encodePassword(passwordEncoder);
-        OfficeOwner officeOwner = officeOwnerRepository.save(signupRequest.toEntity());
-        return Auth.SignUpResponseOfficeOwner.builder().officeOwner(officeOwner).build();
+  @Transactional
+  public Auth.SignUpResponseOfficeOwner register(Auth.SignUpOfficeOwner signupRequest) {
+    if (officeOwnerRepository.existsByEmail(signupRequest.getEmail())) {
+      throw new CustomException(CustomErrorCode.EMAIL_ALREADY_REGISTERED);
     }
 
-    /*
-        Customer 로그인
-        1. client에서 보내온 이메일, 비밀번호는 일치하는지 확인
-        2. jwt 토큰 발급
-        3. LoginReponse Dto 객체에 로그인 회원 정보와 jwt토큰을 실어서 controller에 전달
-     */
-    public LoginResponseCustomer loginCustomer(Auth.SignIn request){
+    signupRequest.encodePassword(passwordEncoder);
+    OfficeOwner officeOwner = officeOwnerRepository.save(signupRequest.toEntity());
+    return Auth.SignUpResponseOfficeOwner.builder().officeOwner(officeOwner).build();
+  }
 
-        Customer customer = customerRepository.findByEmail(request.getEmail())
-            .orElseThrow(() -> new CustomException(CustomErrorCode.EMAIL_NOT_REGISTERED));
+  /*
+      Customer 로그인
+      1. client에서 보내온 이메일, 비밀번호는 일치하는지 확인
+      2. jwt 토큰 발급
+      3. LoginReponse Dto 객체에 로그인 회원 정보와 jwt토큰을 실어서 controller에 전달
+   */
+  @Transactional
+  public LoginResponseCustomer loginCustomer(Auth.SignIn request) {
 
-        if (!passwordEncoder.matches(request.getPassword(), customer.getPassword())) {
-            throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
-        }
+    Customer customer = customerRepository.findByEmail(request.getEmail())
+        .orElseThrow(() -> new CustomException(CustomErrorCode.EMAIL_NOT_REGISTERED));
 
-        String token = tokenProvider.generateToken(customer.getId(), customer.getName(), "customer");
-
-        return LoginResponseCustomer.builder()
-            .customer(customer)
-            .token(token)
-            .build();
+    if (!passwordEncoder.matches(request.getPassword(), customer.getPassword())) {
+      throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
     }
 
-    /*
-        OfficeOwner 로그인
-        1. client에서 보내온 이메일, 비밀번호는 일치하는지 확인
-        2. jwt 토큰 발급
-        3. LoginReponse Dto 객체에 로그인 회원 정보와 jwt토큰을 실어서 controller에 전달
-     */
-    public LoginResponseOfficeOwner loginOfficeOwner(SignIn request) {
-        OfficeOwner officeOwner = officeOwnerRepository.findByEmail(request.getEmail())
-            .orElseThrow(() -> new CustomException(CustomErrorCode.EMAIL_NOT_REGISTERED));
+    String token = tokenProvider.generateToken(customer.getId(), customer.getName(), "customer");
 
-        if (!passwordEncoder.matches(request.getPassword(), officeOwner.getPassword())) {
-            throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
-        }
+    return LoginResponseCustomer.builder()
+        .customer(customer)
+        .token(token)
+        .build();
+  }
 
-        String token = tokenProvider.generateToken(officeOwner.getId(), officeOwner.getName(), "agent");
+  /*
+      OfficeOwner 로그인
+      1. client에서 보내온 이메일, 비밀번호는 일치하는지 확인
+      2. jwt 토큰 발급
+      3. LoginReponse Dto 객체에 로그인 회원 정보와 jwt토큰을 실어서 controller에 전달
+   */
+  @Transactional
+  public LoginResponseOfficeOwner loginOfficeOwner(SignIn request) {
+    OfficeOwner officeOwner = officeOwnerRepository.findByEmail(request.getEmail())
+        .orElseThrow(() -> new CustomException(CustomErrorCode.EMAIL_NOT_REGISTERED));
 
-        return LoginResponseOfficeOwner.builder()
-            .officeOwner(officeOwner)
-            .token(token)
-            .build();
+    if (!passwordEncoder.matches(request.getPassword(), officeOwner.getPassword())) {
+      throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
     }
+
+    String token = tokenProvider.generateToken(officeOwner.getId(), officeOwner.getName(), "agent");
+
+    return LoginResponseOfficeOwner.builder()
+        .officeOwner(officeOwner)
+        .token(token)
+        .build();
+  }
 }

--- a/src/main/java/com/dokkebi/officefinder/service/auth/UserDetailService.java
+++ b/src/main/java/com/dokkebi/officefinder/service/auth/UserDetailService.java
@@ -1,0 +1,29 @@
+package com.dokkebi.officefinder.service.auth;
+
+import com.dokkebi.officefinder.exception.CustomErrorCode;
+import com.dokkebi.officefinder.exception.CustomException;
+import com.dokkebi.officefinder.repository.CustomerRepository;
+import com.dokkebi.officefinder.repository.OfficeOwnerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDetailService {
+
+  private final CustomerRepository customerRepository;
+  private final OfficeOwnerRepository officeOwnerRepository;
+
+  public UserDetails loadUserById(String userType, Long id) throws UsernameNotFoundException {
+    if (userType.equals("customer")) {
+      return customerRepository.findById(id)
+          .orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
+    } else {
+      return officeOwnerRepository.findById(id)
+          .orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
+    }
+  }
+
+}

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -7,6 +7,8 @@ spring:
 
   jwt:
     secret: emVyb2Jhc2Utc3ByaW5nLWJvb3QtYXNzaWdubWVudC1kYXRhLXdpdGgtand0LXNlY3JldC1rZXk=
+    token-header: "Authorization"
+    token-prefix: "Bearer "
 
   jpa:
     hibernate:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,8 @@ spring:
 
   jwt:
     secret: Dnjfseiifwi
+    token-header: "Authorization"
+    token-prefix: "Bearer "
 
   redis:
     host: localhost


### PR DESCRIPTION
- yml파일에 jwt.token-header, jwt.token-prefix 정보 추가
- JwtAuthenticationFilter : Jwt 인증 로직 구현
- SecurityConfig : 우선 회원가입, 로그인 api만 security 필터를 거치지 않게 설정함. 추후에 조회api도 필터를 거치지 않게 설정 필요
- TestController : @PreAuthorize로 api 권한 추가 및 user email, user id 추출법 설명하는 testController