### PR TITLE
Feature/notifcation service

### DIFF
--- a/src/main/java/com/dokkebi/officefinder/controller/notification/NotificationController.java
+++ b/src/main/java/com/dokkebi/officefinder/controller/notification/NotificationController.java
@@ -1,0 +1,28 @@
+package com.dokkebi.officefinder.controller.notification;
+
+import com.dokkebi.officefinder.service.notification.NotificationService;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  // 클라이언트의 SSE 연결 요청을 처리하는 엔드 포인트
+  // produces 속성에 text/event-stream을 설정하여 이 엔드포인트가 SSE 연결을 위한 것임을 나타냄
+  @GetMapping(value = "/sub", produces = "text/event-stream")
+  public SseEmitter subscribe(@AuthenticationPrincipal Principal principal,
+      // 만약 연결이 끊기거나 다른 이유로 이벤트를 받지 못하게 된다면, 브라우저는 다시 연결을 시도할때
+      // 이 Last-Event-ID 헤더를 포함하여 어디서부터 데이터를 다시 받아야 하는지 서버에 알림
+      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId){
+
+    return notificationService.subscribe(principal.getName(), lastEventId);
+  }
+}

--- a/src/main/java/com/dokkebi/officefinder/dto/Event.java
+++ b/src/main/java/com/dokkebi/officefinder/dto/Event.java
@@ -1,0 +1,12 @@
+package com.dokkebi.officefinder.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Event {
+  private int eventId;
+  private String eventType;
+  private String eventData;
+}

--- a/src/main/java/com/dokkebi/officefinder/exception/CustomErrorCode.java
+++ b/src/main/java/com/dokkebi/officefinder/exception/CustomErrorCode.java
@@ -19,7 +19,10 @@ public enum CustomErrorCode {
   OFFICE_OVER_CAPACITY(HttpStatus.BAD_REQUEST, "예약하려는 인원 수가 오피스의 최대 인원 수를 능가합니다."),
   INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "오피스 임대를 위한 포인트가 부족합니다."),
   INVALID_OFFICE_ID(HttpStatus.BAD_REQUEST, "아이디에 해당하는 오피스가 존재하지 않습니다."),
-  FAIL_LOGIN(HttpStatus.UNAUTHORIZED,"로그인에 실패하였습니다. 다시 시도해 주십시오.");
+  FAIL_LOGIN(HttpStatus.UNAUTHORIZED,"로그인에 실패하였습니다. 다시 시도해 주십시오."),
+  SSE_SEND_DUMMY_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "더미 데이터 전송에 실패하였습니다."),
+  SSE_SEND_MISSED_EVENTS_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이전 이벤트 전송에 실패하였습니다."),
+  SSE_SEND_LEASE_NOTIFICATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "임대 알림 전송에 실패하였습니다.");
 
   private final HttpStatus httpStatus;
   private final String errorMessage;

--- a/src/main/java/com/dokkebi/officefinder/repository/notification/EmitterRepository.java
+++ b/src/main/java/com/dokkebi/officefinder/repository/notification/EmitterRepository.java
@@ -1,0 +1,24 @@
+package com.dokkebi.officefinder.repository.notification;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepository {
+
+  private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+  public void save(String email, SseEmitter emitter){
+    emitters.put(email, emitter);
+  }
+
+  public void deleteByEmail(String email){
+    emitters.remove(email);
+  }
+
+  public SseEmitter get(String email){
+    return emitters.get(email);
+  }
+}

--- a/src/main/java/com/dokkebi/officefinder/repository/notification/EventRepository.java
+++ b/src/main/java/com/dokkebi/officefinder/repository/notification/EventRepository.java
@@ -1,0 +1,30 @@
+package com.dokkebi.officefinder.repository.notification;
+
+import com.dokkebi.officefinder.dto.Event;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EventRepository {
+
+  private final Map<String, List<Event>> userEvents = new ConcurrentHashMap<>();
+
+  private AtomicInteger globalEventId = new AtomicInteger(0);
+
+  public void addEvent(String email, Event event){
+    event.setEventId(globalEventId.incrementAndGet());
+    userEvents.computeIfAbsent(email, e -> new ArrayList<>()).add(event);
+  }
+
+  public List<Event> getMissedEvents(String email, int lastEventId){
+    return userEvents.getOrDefault(email, new ArrayList<>())
+        .stream()
+        .filter(event -> event.getEventId() > lastEventId)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/dokkebi/officefinder/service/notification/NotificationService.java
+++ b/src/main/java/com/dokkebi/officefinder/service/notification/NotificationService.java
@@ -1,0 +1,97 @@
+package com.dokkebi.officefinder.service.notification;
+
+import com.dokkebi.officefinder.dto.Event;
+import com.dokkebi.officefinder.entity.office.Office;
+import com.dokkebi.officefinder.exception.CustomErrorCode;
+import com.dokkebi.officefinder.exception.CustomException;
+import com.dokkebi.officefinder.repository.notification.EmitterRepository;
+import com.dokkebi.officefinder.repository.notification.EventRepository;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+
+  private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+  private final EmitterRepository emitterRepository;
+
+  private final EventRepository eventRepository;
+
+  // 회원의 email을 바탕으로 SSE 연결을 설정
+  // LastEvenId가 포함된 경우, 연결이 끊긴 이후의 Event들을 전송
+  public SseEmitter subscribe(String email, String lastEventId){
+    SseEmitter emitter = createEmitter(email);
+
+    if(!lastEventId.isEmpty()){
+      sendAfterEvents(emitter, email, lastEventId);
+    }else{
+      sendDummyData(emitter);
+    }
+
+    return emitter;
+  }
+
+  // 임대 알림을 전송하는 메서드
+  public void sendLeaseNotification(Office office){
+    String email = office.getOwner().getEmail();
+    String officeName = office.getName();
+    String message = officeName + " 임대 요청이 들어왔습니다.";
+
+    Event event = new Event();
+    event.setEventType("leaseNotification");
+    event.setEventData(message);
+
+    eventRepository.addEvent(email, event);
+
+    SseEmitter sseEmitter = emitterRepository.get(email);
+
+    if(sseEmitter != null){
+      try{
+        sseEmitter.send(SseEmitter.event().name(event.getEventType()).data(event.getEventData()));
+      }catch(IOException e){
+        throw new CustomException(CustomErrorCode.SSE_SEND_LEASE_NOTIFICATION_FAIL);
+      }
+    }
+  }
+
+  // 첫 연결 시 더미 데이터를 전송하는 메서드
+  // 이벤트가 전송되지 않으면 연결 요청에 오류가 발생하거나 재연결 요청이 발생할 수 있기 때문
+  private void sendDummyData(SseEmitter emitter) {
+    try{
+      emitter.send(SseEmitter.event().name("connect"));
+    }catch(IOException e){
+      throw new CustomException(CustomErrorCode.SSE_SEND_DUMMY_FAIL);
+    }
+  }
+
+  // 주어진 lastEventId 이후의 모든 이벤트를 전송하는 메서드
+  private void sendAfterEvents(SseEmitter emitter, String email, String lastEventId) {
+    int eventId = Integer.parseInt(lastEventId);
+    List<Event> missedEvents = eventRepository.getMissedEvents(email, eventId);
+
+    for(Event event : missedEvents){
+      try{
+        emitter.send(SseEmitter.event().name(event.getEventType()).data(event.getEventData()));
+      }catch(IOException e){
+        throw new CustomException(CustomErrorCode.SSE_SEND_MISSED_EVENTS_FAIL);
+      }
+    }
+  }
+
+  private SseEmitter createEmitter(String email) {
+    SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+    emitterRepository.save(email, emitter);
+
+    emitter.onCompletion(() -> emitterRepository.deleteByEmail(email));
+    emitter.onTimeout(() -> emitterRepository.deleteByEmail(email));
+
+    return emitter;
+  }
+}

--- a/src/test/java/com/dokkebi/officefinder/repository/notification/EmitterRepositoryTest.java
+++ b/src/test/java/com/dokkebi/officefinder/repository/notification/EmitterRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.dokkebi.officefinder.repository.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class EmitterRepositoryTest {
+
+  private EmitterRepository repository;
+  private SseEmitter emitter;
+
+  @BeforeEach
+  void setUp(){
+    repository = new EmitterRepository();
+    emitter = new SseEmitter();
+  }
+
+  @Test
+  @DisplayName("Emitter 저장 테스트")
+  void saveEmitterTest(){
+    //Given
+    String email = "test@example.com";
+
+    //When
+    repository.save(email, emitter);
+
+    //Then
+    assertEquals(emitter, repository.get(email));
+  }
+
+  @Test
+  void deleteEmitterByEmail(){
+    //Given
+    String email = "test@example.com";
+    repository.save(email, emitter);
+
+    //When
+    repository.deleteByEmail(email);
+
+    //Then
+    assertNull(repository.get(email));
+  }
+
+  @Test
+  void getEmitterTest(){
+    //Given
+    String email = "test@example.com";
+    repository.save(email, emitter);
+
+    //When
+    SseEmitter retrievedEmitter = repository.get(email);
+
+    //Then
+    assertEquals(emitter, retrievedEmitter);
+  }
+}

--- a/src/test/java/com/dokkebi/officefinder/repository/notification/EventRepositoryTest.java
+++ b/src/test/java/com/dokkebi/officefinder/repository/notification/EventRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.dokkebi.officefinder.repository.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.dokkebi.officefinder.dto.Event;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EventRepositoryTest {
+
+  private EventRepository eventRepository;
+
+  @BeforeEach
+  void setup(){
+    eventRepository = new EventRepository();
+  }
+
+  @Test
+  @DisplayName("이벤트 저장시 아이디 증가(1,2 ...) 테스트")
+  void addEvent_IncreaseIdTest(){
+    // Given
+    String email = "test@example.com";
+    Event event1 = new Event();
+    Event event2 = new Event();
+
+    // When
+    eventRepository.addEvent(email, event1);
+    eventRepository.addEvent(email, event2);
+
+    // Then
+    assertEquals(1, event1.getEventId());
+    assertEquals(2, event2.getEventId());
+  }
+
+  @Test
+  @DisplayName("Last-Event-ID 이후에 Event들을 클라이언트에게 전달하는지 테스트")
+  void getMissedEvents_shouldReturnEventsAfterGivenId(){
+    // Given
+    String email = "test@example.com";
+    Event event1 = new Event();
+    Event event2 = new Event();
+    eventRepository.addEvent(email, event1);
+    eventRepository.addEvent(email, event2);
+
+    // When
+    List<Event> missedEvents = eventRepository.getMissedEvents(email, 1);
+
+    // Then
+    assertFalse(missedEvents.contains(event1));
+    assertTrue(missedEvents.contains(event2));
+  }
+
+
+}

--- a/src/test/java/com/dokkebi/officefinder/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/dokkebi/officefinder/service/notification/NotificationServiceTest.java
@@ -1,0 +1,95 @@
+package com.dokkebi.officefinder.service.notification;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dokkebi.officefinder.dto.Event;
+import com.dokkebi.officefinder.entity.OfficeOwner;
+import com.dokkebi.officefinder.entity.office.Office;
+import com.dokkebi.officefinder.repository.notification.EmitterRepository;
+import com.dokkebi.officefinder.repository.notification.EventRepository;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Mock
+  private EmitterRepository emitterRepository;
+
+  @Mock
+  private EventRepository eventRepository;
+
+  @InjectMocks
+  private NotificationService notificationService;
+
+  @Test
+  @DisplayName("lastId가 있는 경우, 전달되지 않았던 이벤트 전송")
+  public void testSubscribe_WithLastEventId() {
+    // Given
+    String email = "test@example.com";
+    String lastEventId = "1";
+
+    when(eventRepository.getMissedEvents(email, Integer.parseInt(lastEventId)))
+        .thenReturn(Arrays.asList(new Event(), new Event()));
+
+    // When
+    SseEmitter returnedEmitter = notificationService.subscribe(email, lastEventId);
+
+    // Then
+    assertNotNull(returnedEmitter);
+    verify(eventRepository).getMissedEvents(email, Integer.parseInt(lastEventId));
+  }
+
+  @Test
+  @DisplayName("lastId가 없는 경우, 더미 데이터 전송")
+  public void testSubscribe_WithoutLastEventId() {
+    // Given
+    String email = "test@example.com";
+    String lastEventId = "";
+
+    // When
+    SseEmitter returnedEmitter = notificationService.subscribe(email, lastEventId);
+
+    // Then
+    assertNotNull(returnedEmitter);
+    verify(emitterRepository).save(eq(email), any());
+  }
+
+  @Test
+  @DisplayName("임대 알림을 보내는 경우")
+  public void testSendLeaseNotification() throws Exception{
+    // Given
+    Office mockOffice = mock(Office.class);
+    OfficeOwner mockOwner = mock(OfficeOwner.class);
+
+    String email = "test@example.com";
+    String officeName = "testOffice";
+    String expectedMessage = officeName + " 임대 요청이 들어왔습니다.";
+
+    when(mockOffice.getOwner()).thenReturn(mockOwner);
+    when(mockOwner.getEmail()).thenReturn(email);
+    when(mockOffice.getName()).thenReturn(officeName);
+
+    SseEmitter mockEmitter = mock(SseEmitter.class);
+    when(emitterRepository.get(email)).thenReturn(mockEmitter);
+
+    // When
+    notificationService.sendLeaseNotification(mockOffice);
+
+    // Then
+    verify(emitterRepository).get(email);
+    verify(mockEmitter).send(any(SseEmitter.SseEventBuilder.class));
+  }
+}


### PR DESCRIPTION
SSE(Server-Sent Events)를 이용하여 실시간 알림 기능을 도입하였습니다.
현재는 사무실 임대에 관한 알림만 구현되어 있으나, 다양한 이벤트에 대한 알림은 후속 작업에서 추가될 예정입니다.

Event 객체 : 서버와 클라이언트 간에 실시간으로 전송되는 이벤트(알림) 정보를 나타냅니다.
Emitter : SSE(Server-Sent Events)의 연결을 관리하고, 이벤트를 클라이언트에게 전송하는 역할을 합니다.
로직은 다음과 같이 동작합니다.

처음 시작 시 : /sub 엔드포인트로 요청을 보내서 SSE를 연결합니다.
연결 후 : 서버에서는 클라이언트에게 이벤트를 실시간으로 전송할 수 있습니다.
lastEventId가 포함된 경우 : 연결이 끊긴 이후의 이벤트를 전송하도록 구현하였습니다.
임대 알림의 경우 사무실이 임대되었을때 해당 사무실의 임대업자에 대해 알림을 전송합니다.