### PR TITLE
Feature/agent lookup lease requests

### DIFF
--- a/src/main/java/com/dokkebi/officefinder/controller/lease/LeaseController.java
+++ b/src/main/java/com/dokkebi/officefinder/controller/lease/LeaseController.java
@@ -1,5 +1,6 @@
 package com.dokkebi.officefinder.controller.lease;
 
+import com.dokkebi.officefinder.controller.lease.dto.LeaseControllerDto.AgentLeaseLookUpResponse;
 import com.dokkebi.officefinder.controller.lease.dto.LeaseControllerDto.LeaseLookUpResponse;
 import com.dokkebi.officefinder.controller.lease.dto.LeaseControllerDto.LeaseSuccessResponse;
 import com.dokkebi.officefinder.controller.lease.dto.LeaseControllerDto.LeaseOfficeRequest;
@@ -41,7 +42,8 @@ public class LeaseController {
   }
 
   @GetMapping("/customers/info/leases")
-  public Page<LeaseLookUpResponse> getLeaseInfo(Principal principal, @RequestParam(defaultValue = "0") Integer page,
+  public Page<LeaseLookUpResponse> getLeaseInfo(Principal principal,
+      @RequestParam(defaultValue = "0") Integer page,
       @RequestParam(defaultValue = "20") Integer size) {
 
     // 기본적으로 임대 정보가 생성 되었던 시간에 따라 내림차순으로 정렬
@@ -51,5 +53,15 @@ public class LeaseController {
         principal.getName(), pageable);
 
     return serviceResponses.map(LeaseLookUpResponse::of);
+  }
+
+  @GetMapping("/agents/offices/{officeId}/lease-requests")
+  public Page<AgentLeaseLookUpResponse> getLeaseRequest(Principal principal,
+      @PathVariable Long officeId, @RequestParam(defaultValue = "0") Integer page,
+      @RequestParam(defaultValue = "5") Integer size) {
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt"));
+
+    return leaseService.getLeaseRequestList(principal.getName(), officeId, pageable);
   }
 }

--- a/src/main/java/com/dokkebi/officefinder/controller/lease/dto/LeaseControllerDto.java
+++ b/src/main/java/com/dokkebi/officefinder/controller/lease/dto/LeaseControllerDto.java
@@ -1,5 +1,6 @@
 package com.dokkebi.officefinder.controller.lease.dto;
 
+import com.dokkebi.officefinder.entity.lease.Lease;
 import com.dokkebi.officefinder.entity.type.LeaseStatus;
 import com.dokkebi.officefinder.service.lease.dto.LeaseServiceDto.LeaseLookUpServiceResponse;
 import com.dokkebi.officefinder.service.lease.dto.LeaseServiceDto.LeaseOfficeServiceResponse;
@@ -95,6 +96,39 @@ public class LeaseControllerDto {
           .endDate(resp.getEndDate())
           .isMonthly(resp.isMonthlyPay())
           .isReviewed(resp.isReviewed())
+          .build();
+    }
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class AgentLeaseLookUpResponse{
+
+    private Long leaseId;
+
+    private String customerName;
+
+    private String customerEmail;
+
+    private String officeName;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private Long price;
+
+    public static AgentLeaseLookUpResponse of(Lease lease, String officeName){
+      return AgentLeaseLookUpResponse.builder()
+          .leaseId(lease.getId())
+          .customerName(lease.getCustomer().getName())
+          .customerEmail(lease.getCustomer().getEmail())
+          .officeName(officeName)
+          .startDate(lease.getLeaseStartDate())
+          .endDate(lease.getLeaseEndDate())
+          .price(lease.getPrice())
           .build();
     }
   }

--- a/src/main/java/com/dokkebi/officefinder/exception/CustomErrorCode.java
+++ b/src/main/java/com/dokkebi/officefinder/exception/CustomErrorCode.java
@@ -22,7 +22,9 @@ public enum CustomErrorCode {
   FAIL_LOGIN(HttpStatus.UNAUTHORIZED,"로그인에 실패하였습니다. 다시 시도해 주십시오."),
   SSE_SEND_DUMMY_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "더미 데이터 전송에 실패하였습니다."),
   SSE_SEND_MISSED_EVENTS_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이전 이벤트 전송에 실패하였습니다."),
-  SSE_SEND_LEASE_NOTIFICATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "임대 알림 전송에 실패하였습니다.");
+  SSE_SEND_LEASE_NOTIFICATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "임대 알림 전송에 실패하였습니다."),
+  OFFICE_NOT_OWNED_BY_OWNER(HttpStatus.NOT_FOUND, "해당 사용자가 소유하고 있는 오피스가 아닙니다."),
+  OWNER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 이메일을 가진 임대업자를 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String errorMessage;

--- a/src/main/java/com/dokkebi/officefinder/repository/lease/LeaseRepository.java
+++ b/src/main/java/com/dokkebi/officefinder/repository/lease/LeaseRepository.java
@@ -10,4 +10,8 @@ public interface LeaseRepository extends JpaRepository<Lease, Long>, LeaseReposi
 
   @Query("select l from Lease l join fetch l.customer join fetch l.office where l.id = :leaseId")
   Optional<Lease> findById(@Param("leaseId") Long leaseId);
+
+//  @Query("select l from Lease l join fetch l.customer where l.office = :office "
+//      + "and l.leaseStatus = :leaseStatus")
+//  Page<Lease> findByOfficeAndLeaseStatus(Office office, LeaseStatus leaseStatus, Pageable pageable);
 }

--- a/src/main/java/com/dokkebi/officefinder/repository/lease/LeaseRepositoryCustom.java
+++ b/src/main/java/com/dokkebi/officefinder/repository/lease/LeaseRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.dokkebi.officefinder.repository.lease;
 
 import com.dokkebi.officefinder.entity.lease.Lease;
+import com.dokkebi.officefinder.entity.office.Office;
+import com.dokkebi.officefinder.entity.type.LeaseStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface LeaseRepositoryCustom {
 
   Page<Lease> findByCustomerId(Long customerId, Pageable pageable);
+
+  Page<Lease> findByOfficeIdAndLeaseStatus(Long officeId, LeaseStatus leaseStatus,Pageable pageable);
 }

--- a/src/main/java/com/dokkebi/officefinder/repository/lease/LeaseRepositoryImpl.java
+++ b/src/main/java/com/dokkebi/officefinder/repository/lease/LeaseRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.dokkebi.officefinder.entity.lease.QLease.lease;
 import static com.dokkebi.officefinder.entity.office.QOffice.office;
 
 import com.dokkebi.officefinder.entity.lease.Lease;
+import com.dokkebi.officefinder.entity.type.LeaseStatus;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -43,4 +44,32 @@ public class LeaseRepositoryImpl implements LeaseRepositoryCustom{
 
     return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
   }
+
+  @Override
+  public Page<Lease> findByOfficeIdAndLeaseStatus(Long officeId, LeaseStatus leaseStatus,
+      Pageable pageable) {
+
+    List<Lease> content = queryFactory.selectFrom(lease)
+        .join(lease.customer, customer).fetchJoin()
+        .join(lease.office, office).fetchJoin()
+        .where(
+            office.id.eq(officeId),
+            lease.leaseStatus.eq(leaseStatus)
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Long> countQuery = queryFactory.select(lease.count())
+        .from(lease)
+        .join(lease.customer, customer).fetchJoin()
+        .join(lease.office, office).fetchJoin()
+        .where(
+            office.id.eq(officeId),
+            lease.leaseStatus.eq(leaseStatus)
+        );
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+  }
+
 }

--- a/src/main/java/com/dokkebi/officefinder/repository/office/OfficeRepository.java
+++ b/src/main/java/com/dokkebi/officefinder/repository/office/OfficeRepository.java
@@ -1,8 +1,10 @@
 package com.dokkebi.officefinder.repository.office;
 
+import com.dokkebi.officefinder.entity.OfficeOwner;
 import com.dokkebi.officefinder.entity.office.Office;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OfficeRepository extends JpaRepository<Office, Long>, OfficeRepositoryCustom {
-
+  Optional<Office> findByOwnerAndId(OfficeOwner officeOwner, Long officeId);
 }


### PR DESCRIPTION
특정 오피스에 대한 임대 요청 리스트 조회 기능을 구현하고, 테스트 코드를 작성하였습니다.

로직은 다음과 같이 동작합니다.
- officeId와 회원 정보를 바탕으로 Office와 OfficeOwner를 조회합니다.
- 수락 대기 상태(LeaseStatus.AWAIT)에 있는 임대 요청 리스트를 리턴합니다.
- 조회 후 임대업자는 임대 요청을 수락 또는 거절할 수 있습니다.(추후 바로 구현)