### PR TITLE
Refactor/accept lease request

### DIFF
--- a/src/main/java/com/dokkebi/officefinder/service/lease/LeaseService.java
+++ b/src/main/java/com/dokkebi/officefinder/service/lease/LeaseService.java
@@ -113,6 +113,7 @@ public class LeaseService {
     return awaitList.map(l -> AgentLeaseLookUpResponse.of(l, office.getName()));
   }
 
+  @Transactional
   public void acceptLeaseRequest(Long leaseId) {
     Lease lease = leaseRepository.findByLeaseId(leaseId)
         .orElseThrow(() -> new CustomException(LEASE_NOT_FOUND));


### PR DESCRIPTION
- 기존 acceptLeaseRequest 메서드에 @Transactional 어노테이션이 누락되어 있어 JPA의 더티체킹이 제대로 작동하지 않았습니다.따라서 변경된 임대 상태가 데이터베이스에 반영되지 않는 문제가 발생하였습니다.

- 이를 해결하기 위해 @Transactional 어노테이션을 메서드에 추가하여 상태 변경을 올바르게 반영하도록 했습니다.